### PR TITLE
SetReplace infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: maxitg/set-replace:ci
+        auth:
+          username: maxitg
+          password: $DOCKERHUB_PASSWORD
+
+    steps:
+      - checkout
+
+      - run:
+          name: Build
+          command: ./build.wls
+
+      - run:
+          name: Install
+          command: ./install.wls
+
+      - run:
+          name: Reinstall
+          command: ./install.wls
+
+      - run:
+          name: Test
+          command: ./.circleci/test.sh

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rm -f exit_status.txt
+STATUS_FILE=1 ./test.wls
+[[ -f exit_status.txt && $(< exit_status.txt) == "0" ]]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature
+assignees: ''
+
+---
+
+### The problem
+Is your feature request related to a problem? Please describe. Ex. I'm always frustrated when [...]
+
+### Possible solution
+A clear and concise description of what you want to happen.
+
+### Alternative solutions
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/weed_report.md
+++ b/.github/ISSUE_TEMPLATE/weed_report.md
@@ -1,0 +1,32 @@
+---
+name: Weed report
+about: Report something that is not working to help us improve
+title: ''
+labels: weed
+assignees: ''
+
+---
+
+### The problem
+A clear and concise description of what is not working.
+```wl
+In[] := minimal input that is not working
+```
+image of the actual output.
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Version
+```wl
+In[] := SystemInformation["Small"]
+```
+image of the output
+
+```wl
+In[] := $PlanckClockGitSHA
+```
+paste the output here without quotes.
+
+### Additional context
+Add any other context or screenshots about the weed report here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Changes
+* Reference resolved issues.
+* Add a few comments about what this pull request changes.
+
+## Comments
+* Add comments for the reviewer.
+
+## Examples
+* Add explicit inputs and outputs (as screenshots in case of graphics) showcasing new functionality.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 # macOS
 
 *.DS_Store
+
+# Build directory
+
+Build/
+
+# Built paclets
+
+*.paclet

--- a/Kernel/buildData.m
+++ b/Kernel/buildData.m
@@ -1,0 +1,16 @@
+(* The backtick magic is necessary to prevent it being interpreted as a beginning of a template argument. *)
+Package["PlanckClock<*"`"*>"]
+
+PackageExport["$PlanckClockGitSHA"]
+PackageExport["$PlanckClockBuildTime"]
+
+$PlanckClockGitSHA::usage = usageString[
+  "$PlanckClockGitSHA gives the Git SHA of the repository from which PlanckClock was built."];
+
+$PlanckClockBuildTime::usage = usageString[
+  "$PlanckClockBuildTime gives the date object at which PlanckClock was built."];
+
+(* This is a template file. Data is inserted at build time. *)
+
+$PlanckClockGitSHA = <*ToString[gitSHA[], InputForm]*>; (* gitSHA[] is defined in buildInit.wl *)
+$PlanckClockBuildTime = <*ToString[DateObject[TimeZone -> "UTC"], InputForm]*>;

--- a/Kernel/init.m
+++ b/Kernel/init.m
@@ -1,0 +1,7 @@
+Unprotect["PlanckClock`*"];
+
+ClearAll @@ (# <> "*" & /@ Contexts["PlanckClock`*"]);
+
+Get["PlanckClock`Kernel`usageString`"];
+
+SetAttributes[#, {Protected, ReadProtected}] & /@ Evaluate @ Names @ "PlanckClock`*";

--- a/Kernel/testUtilities.m
+++ b/Kernel/testUtilities.m
@@ -1,0 +1,31 @@
+Package["PlanckClock`"]
+
+PackageScope["testUnevaluated"]
+PackageScope["testSymbolLeak"]
+
+(* VerificationTest should not directly appear here, as it is replaced by test.wls into other heads during evaluation.
+    Use testHead argument instead. *)
+
+(* It is necessary to compare strings because, i.e.,
+    MatchQ[<|x -> 1|>, HoldPattern[<|x -> 1|>]] returns False. *)
+Attributes[testUnevaluated] = {HoldAll};
+testUnevaluated[testHead_, input_, messages_, opts___] :=
+  testHead[
+    ToString[FullForm[input]],
+    StringReplace[ToString[FullForm[Hold[input]]], StartOfString ~~ "Hold[" ~~ expr___ ~~ "]" ~~ EndOfString :> expr],
+    messages,
+    opts];
+
+Attributes[testSymbolLeak] = {HoldAll};
+testSymbolLeak[testHead_, expr_, opts___] :=
+  testHead[
+    Module[{Global`before, Global`after},
+      expr; (* symbols might get created at the first run due to initialization *)
+      Global`before = Length[Names["*`*"]];
+      expr;
+      Global`after = Length[Names["*`*"]];
+      Global`after - Global`before
+    ],
+    0,
+    opts
+  ];

--- a/Kernel/usageString.m
+++ b/Kernel/usageString.m
@@ -1,0 +1,35 @@
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*usageString*)
+
+
+(* ::Text:: *)
+(*A function to create usage strings with correct style for arguments.*)
+
+
+Package["PlanckClock`"]
+
+
+PackageScope["usageString"]
+
+
+(* ::Subsection:: *)
+(*Argument style definitions*)
+
+
+argStyle[arg_Integer] := "TR";
+argStyle["\[Ellipsis]"] := "TR";
+argStyle[str_String] := "TI";
+
+
+argString[arg_] :=
+  "\!\(\*StyleBox[\"" <> ToString[arg] <> "\", \"" <> argStyle[arg] <> "\"]\)"
+
+
+(* ::Subsection:: *)
+(*Implementation*)
+
+
+usageString[str__] :=
+  (StringTemplate[StringJoin[{str}]] /. {TemplateSlot[s_] :> argString[s]})[]

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,0 +1,14 @@
+(* ::Package:: *)
+
+Paclet[
+  Name -> "PlanckClock",
+  Version -> "0.1",
+  MathematicaVersion -> "12.1+",
+  Description -> "PlanckClock implements functions used to work with Planck clock.",
+  Creator -> "Max Piskunov",
+  URL -> "https://github.com/maxitg/PlanckClock",
+  SystemID -> {"MacOSX-x86-64", "Linux-x86-64", "Windows-x86-64"},
+  Extensions -> {
+    {"Kernel", Context -> "PlanckClock`"}
+  }
+]

--- a/Tests/buildData.wlt
+++ b/Tests/buildData.wlt
@@ -1,0 +1,37 @@
+<|
+  "$PlanckClockGitSHA" -> <|
+    "tests" -> {
+      VerificationTest[
+        StringLength @ $PlanckClockGitSHA,
+        40
+      ],
+
+      VerificationTest[
+        StringMatchQ[$PlanckClockGitSHA, HexadecimalCharacter...]
+      ]
+    }
+  |>,
+
+  "$PlanckClockBuildTime" -> <|
+    "tests" -> {
+      VerificationTest[
+        DateObjectQ @ $PlanckClockBuildTime
+      ],
+
+      VerificationTest[
+        $PlanckClockBuildTime["TimeZone"],
+        "UTC"
+      ],
+
+      (* could not be built in the future *)
+      VerificationTest[
+        $PlanckClockBuildTime < Now
+      ],
+
+      (* could not be built before $PlanckClockBuildTime was implemented *)
+      VerificationTest[
+        DateObject[{2020, 5, 12, 0, 0, 0}, TimeZone -> "UTC"] < $PlanckClockBuildTime
+      ]
+    }
+  |>
+|>

--- a/Tests/meta.wlt
+++ b/Tests/meta.wlt
@@ -1,0 +1,49 @@
+<|
+  "meta" -> <|
+    "init" -> (
+      $testsDirectory = If[$TestFileName =!= "",
+        FileNameJoin[Most @ FileNameSplit @ $TestFileName],
+        FileNameJoin[Append[Most[FileNameSplit[$ScriptCommandLine[[1]]]], "Tests"]]
+      ];
+    ),
+    "tests" -> {
+      (* All public symbols have usage message *)
+
+      VerificationTest[
+        AllTrue[
+          ReleaseHold[{Function[symbol, MessageName[symbol, "usage"], HoldFirst] /@
+            ("PackageExports" /. Package`PackageInformation["PlanckClock`"])}],
+          StringQ]
+      ],
+
+      (* All public symbols have syntax information *)
+
+      VerificationTest[
+        AllTrue[
+          ReleaseHold[{Function[
+              symbol,
+              {SymbolName[Unevaluated[symbol]], SyntaxInformation[symbol]},
+              HoldFirst] /@
+            ("PackageExports" /. Package`PackageInformation["PlanckClock`"])}],
+          If[StringStartsQ[#[[1]], "$"], #[[2]] === {}, #[[2]] =!= {}] &]
+      ],
+
+      (* Test coverage: all public symbols appear in unit tests *)
+
+      With[{testsDirectory = $testsDirectory}, VerificationTest[
+        AllTrue[
+          ReleaseHold[{Function[
+              symbol,
+              SymbolName[Unevaluated[symbol]],
+              HoldFirst] /@
+            ("PackageExports" /. Package`PackageInformation["PlanckClock`"])}],
+          StringContainsQ[StringJoin[Import[
+            FileNameJoin[Append[FileNameSplit @ testsDirectory, "*.wlt"]],
+            "Text"]], #] &]
+      ]]
+    },
+    "options" -> {
+      "Parallel" -> False
+    }
+  |>
+|>

--- a/build.wls
+++ b/build.wls
@@ -1,0 +1,28 @@
+#!/usr/bin/env wolframscript
+
+Check[
+  Get[FileNameJoin[{DirectoryName[$InputFileName], "scripts", "buildInit.wl"}]];
+  deleteBuildDirectory[];,
+
+  Exit[1];
+];
+
+$success = True;
+
+Check[
+  copyWLSourceToBuildDirectory[];
+  $version = updateVersion[];
+  updateBuildData[];
+  packPaclet[];
+  deleteBuildDirectory[];,
+
+  Exit[1];
+];
+
+If[$success,
+  Print["Build done."];
+  Exit[0];,
+
+  Print["Build failed."];
+  Exit[1];
+];

--- a/install.wls
+++ b/install.wls
@@ -1,0 +1,28 @@
+#!/usr/bin/env wolframscript
+
+$successQ = True;
+
+(* If any messages are produced, fail with non-zero exit code. *)
+Check[
+  $repoRoot = DirectoryName[$InputFileName];
+  $latestPacletFiles = MaximalBy[
+    FileNames[FileNameJoin[{$repoRoot, "PlanckClock-*.paclet"}]], FileInformation[#, "LastModificationDate"] &];
+  
+  If[Length[$latestPacletFiles] == 0,
+    Print[
+      "No paclet files PlanckClock-*.paclet were found. ",
+      "Run ./build.wls."];
+    Exit[1];
+  ];
+
+  If[PacletFind["PlanckClock"] =!= {}, PacletUninstall["PlanckClock"]];
+
+  If[PacletObjectQ[PacletInstall[First[$latestPacletFiles], "IgnoreVersion" -> True]],
+    Print["Installed. Restart running kernels to complete installation."],
+    Print["Install failed."];
+    $successQ = False];,
+
+  $successQ = False;
+];
+
+Exit[If[$successQ, 0, 1]]

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -1,0 +1,60 @@
+Needs["PacletManager`"];
+
+If[PacletFind["GitLink", "Internal" -> All] === {},
+  PacletInstall["https://www.wolframcloud.com/obj/maxp1/GitLink-2019.11.26.01.paclet"];
+];
+Needs["GitLink`"];
+
+$repoRoot = FileNameJoin[{DirectoryName[$InputFileName], ".."}];
+$buildDirectory = FileNameJoin[{$repoRoot, "Build"}];
+
+deleteBuildDirectory[] := If[FileExistsQ[$buildDirectory], DeleteDirectory[$buildDirectory, DeleteContents -> True]];
+
+copyWLSourceToBuildDirectory[] := With[{
+    files = Append[Import[FileNameJoin[{$repoRoot, "Kernel"}]], FileNameJoin[{"..", "PacletInfo.m"}]]},
+  If[!FileExistsQ[#], CreateDirectory[#]] & /@ {$buildDirectory, FileNameJoin[{$buildDirectory, "Kernel"}]};
+  CopyFile[FileNameJoin[{$repoRoot, "Kernel", #}], FileNameJoin[{$buildDirectory, "Kernel", #}]] & /@ files;
+];
+
+$baseVersionPacletMessage = "Will create paclet with the base version number.";
+updateVersion::noGitLink = "Could not find GitLink. " <> $baseVersionPacletMessage;
+
+updateVersion[] /; Names["GitLink`*"] =!= {} := Module[{
+    versionInformation, gitRepo, minorVersionNumber, versionString, pacletInfoFilename, pacletInfo},
+  Check[
+    versionInformation = Import[FileNameJoin[{$repoRoot, "scripts", "version.wl"}]];
+    gitRepo = GitOpen[$repoRoot];
+    minorVersionNumber = Max[0, Length[GitRange[
+      gitRepo, Except[versionInformation["Checkpoint"]], GitMergeBase[gitRepo, "HEAD", "master"]]] - 1];
+    pacletInfoFilename = FileNameJoin[{$buildDirectory, "PacletInfo.m"}];
+    pacletInfo = Association @@ Import[pacletInfoFilename];
+    versionString = pacletInfo[Version] <> "." <> ToString[minorVersionNumber];,
+
+    Return[]];
+
+  Export[pacletInfoFilename, Paclet @@ Normal[Join[pacletInfo, <|Version -> versionString|>]]];
+  versionString
+];
+
+updateVersion[] /; Names["GitLink`*"] === {} := Message[updateVersion::noGitLink];
+
+gitSHA[] /; Names["GitLink`*"] =!= {} := Module[{gitRepo, sha, cleanQ},
+  gitRepo = GitOpen[$repoRoot];
+  sha = GitSHA[gitRepo, gitRepo["HEAD"]];
+  cleanQ = AllTrue[# === {} &]@GitStatus[gitRepo];
+  If[cleanQ, sha, sha <> "*"]
+]
+
+gitSHA::noGitLink = "Could not find GitLink. $PlanckClockGitSHA will not be available.";
+
+gitSHA[] /; Names["GitLink`*"] === {} := (
+  Message[gitSHA::noGitLink];
+  Missing["NotAvailable"]
+)
+
+updateBuildData[] := With[{
+    buildDataFile = File[FileNameJoin[{$buildDirectory, "Kernel", "buildData.m"}]]},
+  FileTemplateApply[buildDataFile, buildDataFile];
+]
+
+packPaclet[] := PackPaclet[$buildDirectory, $repoRoot]

--- a/scripts/version.wl
+++ b/scripts/version.wl
@@ -1,0 +1,3 @@
+<|
+  "Checkpoint" -> "9aee8f3397fc80debbecf66138b243edbdc7200d"
+|>

--- a/test.wls
+++ b/test.wls
@@ -1,0 +1,152 @@
+#!/usr/bin/env wolframscript
+
+(* Disable messages about outdated cloud. *)
+Off[CloudConnect::clver];
+
+<< PlanckClock`;
+(* Launch kernels preemptively to avoid "Launching kernels..." interrupting test log *)
+CloseKernels[];
+LaunchKernels[];
+ParallelEvaluate[<< PlanckClock`];
+
+$successQ = True;
+
+(* Get test files *)
+
+$testFiles = If[Length @ $ScriptCommandLine >= 2,
+  FileNameJoin[{".", "Tests", # <> ".wlt"}] & /@ $ScriptCommandLine[[2 ;; ]],
+  FileNames[FileNameJoin[{".", "Tests", "*.wlt"}]]
+];
+
+If[!FileExistsQ[#],
+  Print["Test file ", #, " does not exist."];
+  Exit[1];] & /@ $testFiles;
+
+(* Read tests *)
+
+$testGroups = Join @@ (
+  KeyMap[ReleaseHold, #] & /@
+    ReleaseHold @ Map[Hold, ToExpression[Import[#, "Text"], InputForm, Hold], {5}] & /@ $testFiles);
+
+Attributes[test] = Attributes[constrainedTest] = {HoldAll};
+
+$singleTestTimeConstraint = 300;
+$singleTestMemoryConstraint = 1*^9;
+constrainedTest[args___] := With[{
+    timeConstraintOpt =
+      If[FreeQ[Hold[{args}], TimeConstraint], {TimeConstraint -> $singleTestTimeConstraint}, {}],
+    memoryConstraintOpt =
+      If[FreeQ[Hold[{args}], MemoryConstraint], {MemoryConstraint -> $singleTestMemoryConstraint}, {}]},
+  test[args, ##] & @@ Join[timeConstraintOpt, memoryConstraintOpt]
+];
+
+removeHoldFormFromInputString[input_String] := StringReplace[
+  input,
+  StartOfString ~~ "HoldForm[" ~~ expr__ ~~ "]" ~~ EndOfString :> expr
+];
+
+$results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{
+    testList, testResults, testReport, options, parallelQ, runInit, failedTests},
+  (* Notify the user which test group we are running *)
+  WriteString["stdout",
+    testGroupName,
+    StringJoin[ConstantArray[" ", Max[40 - StringLength[testGroupName], 1]]]];
+
+  (* Read options *)
+  options = Association[ReleaseHold[Lookup[testGroup, "options", <||>]]];
+  parallelQ = Lookup[options, "Parallel", True];
+
+  (* Run init, changing VerificationTest to test in all definitions *)
+  runInit[] := ReleaseHold[testGroup["init"] /. VerificationTest -> constrainedTest];
+  runInit[];
+  If[parallelQ, ParallelEvaluate[runInit[]]];
+
+  (* Make a list of tests, but don't run them yet *)
+  testList = Flatten[ReleaseHold[testGroup["tests"] /. VerificationTest -> constrainedTest]];
+
+  (* Run tests in parallel *)
+  testResults = If[parallelQ, ParallelMap, Map][# /. test -> VerificationTest &, testList];
+  testReport = TestReport[testResults];
+
+  $redColor = "\033[0;31m";
+  $greenColor = "\033[0;32m";
+  $orangeColor = "\033[0;33m";
+  $yellowColor = "\033[1;33m";
+  $endColor = "\033[0m";
+
+  (* Print the summery (green if ok, red if failed) *)
+  WriteString["stdout", If[testReport["AllTestsSucceeded"],
+    $greenColor <> "[ok]" <> $endColor,
+    $successQ = False;
+    StringJoin[
+      $redColor <> "[",
+      ToString @ testReport["TestsFailedCount"],
+      "/",
+      ToString @ Length @ testReport["TestResults"],
+      " failed]" <> $endColor]], "\n"];
+
+  (* If tests failed, print why *)
+  failedTests = Join @@ testReport["TestsFailed"];
+  Switch[#["Outcome"],
+    "Failure",
+      WriteString["stdout",
+        $redColor <> "Input" <> $endColor <> "\n",
+        "> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n\n",
+        $redColor <> "evaluated to" <> $endColor <> "\n",
+        "> ", ToString[#["ActualOutput"], OutputForm], "\n\n",
+        $redColor <> "instead of expected " <> $endColor <> "\n",
+        "> ", ToString[#["ExpectedOutput"], OutputForm], "\n\n\n"],
+    "MessagesFailure",
+      WriteString["stdout",
+        $orangeColor <> "Input" <> $endColor <> "\n",
+        "> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n\n",
+        $orangeColor <> "generated messages" <> $endColor <> "\n",
+        "> ", ToString[#["ActualMessages"], OutputForm], "\n\n",
+        $orangeColor <> "instead of expected" <> $endColor <> "\n",
+        "> ", ToString[#["ExpectedMessages"], OutputForm], "\n\n\n"],
+    "Error",
+      WriteString["stdout",
+        $yellowColor <> "Error while evaluating the test with input" <> $endColor <> "\n",
+        "> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n\n\n"]
+  ] & /@ failedTests[[1 ;; UpTo[3]]];
+
+  (* If too many tests have failed, print how many remain *)
+  If[Length[failedTests] > 3,
+    WriteString["stdout",
+      "Omitting remaining ",
+      Length[failedTests] - 3,
+      " " <> testGroupName,
+      " test failures.\n\n"]
+  ];
+
+  (* Return the report, we'll need it later *)
+  testGroupName -> testReport
+]], $testGroups]];
+
+(* Create a notebook with results *)
+
+$reportFile = UsingFrontEnd @ Export[
+  FileNameJoin[Join[FileNameSplit[CreateDirectory[]], {"testReport.nb"}]],
+  Notebook @ Catenate @ Prepend[KeyValueMap[
+    {Cell[Last @ FileNameSplit @ #1, "Section"],
+      Cell[
+        BoxData[RowBox[{"TestReport", "[", "\"" <> #1 <> "\"", "]"}]],
+        "Input"],
+      Cell[BoxData[ToBoxes[#2]], "Output"]} &,
+    $results], {Cell["PlanckClock Test Report", "Title"]}]];
+
+
+Print["Report file: ", $reportFile];
+
+If[$MessageList =!= {}, $successQ = False];
+
+If[Environment["STATUS_FILE"] === "1",
+  Export["exit_status.txt", If[$successQ, 0, 1]];
+];
+
+If[$successQ,
+  Print["Tests passed."];
+  Exit[0],
+  Print["Tests failed."];
+  Exit[1]
+]


### PR DESCRIPTION
## Changes
* Brings over Wolfram Language paclet infrastructure from [*SetReplace*](https://github.com/maxitg/SetReplace).
* This includes basic utility functions for usage strings, remembering build data, unit tests, tests for test coverage, etc., and build, install and test scripts.
* Also includes issue and pull request templates.

## Comments
* The plan here is to first implement functions such as `ToPlanckTime`, `FromPlanckTime`, `ToPlanckClockString`, `FromPlanckClockString`, and then make a webform for converting back and force between conventional and Planck Clock dates/times.

## Examples
* Run `./build.wls && ./install.wls && ./test.wls` to run `meta` tests:
```
> ./build.wls && ./install.wls && ./test.wls 
Build done.
Installed. Restart running kernels to complete installation.
$PlanckClockGitSHA                      [ok]
$PlanckClockBuildTime                   [ok]
meta                                    [ok]
Report file: /private/var/folders/f_/klrm3n7d4_989wy4dxx9_l9c0000gn/T/m000001953931/testReport.nb
Tests passed.
```