### PR TITLE
Fix PlanckClock in different timezones

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,11 @@
         "</td></tr>";
     }
 
+    // month should start with 1, i.e., for January, month = 1, as is conventional.
+    function dateFromUTC(year, month, day, hour = 0, minute = 0, second = 0) {
+      return new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+    }
+
     function startTime(first) {
       if (first) lastUpd = new Date();
 
@@ -166,17 +171,17 @@
         "<td style = 'text-align: right' width = '200'>Fraction</td>" +
         "<td width = '200' style = 'text-align: right;'>Duration</td></tr>";
 
-      eventTable += event('US Lockdown (estimate)', new Date(2020, 2, 20, 0, 0), new Date(2020, 5, 1, 0, 0));
+      eventTable += event('US Lockdown (estimate)', dateFromUTC(2020, 3, 20), dateFromUTC(2020, 6, 1));
 
       eventTable += "<tr><td></td></tr>";
-      eventTable += event('Wolfram Summer School 12', new Date(2020, 5, 22, 0, 0), new Date(2020, 6, 18, 0, 0));
+      eventTable += event('Wolfram Summer School 12', dateFromUTC(2020, 6, 22), dateFromUTC(2020, 7, 18));
 
       eventTable += "<tr><td></td></tr>";
-      eventTable += event('WP: Quantum Computing', new Date(2020, 4, 21, 15, 0), new Date(2020, 4, 21, 17, 0));
+      eventTable += event('WP: Quantum Computing', dateFromUTC(2020, 5, 21, 19, 0), dateFromUTC(2020, 5, 21, 21, 0));
 
       eventTable += "<tr><td></td></tr>";
-      eventTable += event('HT 8', new Date(2020, 4, 22, 18, 42, 53), new Date(2020, 4, 22, 21, 27, 2));
-      eventTable += event('New Dudec! &#x1F389', new Date(2020, 4, 28, 23, 8, 0), new Date(2021, 0, 17, 9, 6, 36));
+      eventTable += event('HT 8', dateFromUTC(2020, 5, 22, 22, 42, 53), dateFromUTC(2020, 5, 23, 1, 27, 2));
+      eventTable += event('New Dudec! &#x1F389', dateFromUTC(2020, 5, 29, 3, 8, 0), dateFromUTC(2021, 1, 17, 14, 6, 36));
 
       document.getElementById('eventtable').innerHTML = eventTable;
 


### PR DESCRIPTION
## Changes

* Events are now specified in UTC, and are displayed correctly regardless of user's timezone.

## Examples

* Local timezone set to GMT:
<img width="1085" alt="Screen Shot 2020-05-22 at 16 26 35" src="https://user-images.githubusercontent.com/1479325/82688807-02199c80-9c49-11ea-8ebc-6b9c807478ca.png">

* Local timezone set to EDT:
<img width="1085" alt="Screen Shot 2020-05-22 at 12 27 09" src="https://user-images.githubusercontent.com/1479325/82688847-16f63000-9c49-11ea-92e0-7481c738c65f.png">

* As one can see, times displayed are the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/planckclock/11)
<!-- Reviewable:end -->
